### PR TITLE
Make shebang use /usr/bin/env

### DIFF
--- a/tmux_resurrect
+++ b/tmux_resurrect
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #######################
 # Usage
 usage() {


### PR DESCRIPTION
Update shebang for systems where bash sits in different places (BSDs etc.)
