### PR TITLE
Fix window list

### DIFF
--- a/tmux_resurrect
+++ b/tmux_resurrect
@@ -134,7 +134,7 @@ elif [ "${task}" = 'restore' ] ;then
 
   ##Restore proper number of sessions, windows, and panes
   for session in $(ls ${backup_dir} | grep -v '\.size$' | cut -d: -f1 | sort -du) ;do
-    window_list=$(ls ${backup_dir} | awk -F: '/^'${session}':/ {print $2}' | cut -d\. -f1 | sort -nu)
+    window_list=$(ls ${backup_dir} | awk -F: '/^'${session}':/ {print $2}' | sed 's/^\([0-9]*\).*/\1/' | sort -nu)
     window_list_rev=$(echo "${window_list}" | sort -nr)
     num_windows=$(echo ${window_list} | wc -w)
 


### PR DESCRIPTION
The `if [ ${i} -ne ${window} ]` check on line 162 was failing because `${window}` was `0-name`. Here are various commands that led me to replacing `cut` with `sed`:

``` bash
┌─[mzych@marcs-air] - [~/dotfiles] - [Sun Feb 02, 02:03:34]
└─[N]> ls ~/.tmux_resurrect/snapshot
test.size     test:0-name   test:0.0      test:0.1      test:0.layout
┌─[mzych@marcs-air] - [~/dotfiles] - [Sun Feb 02, 02:03:53]
└─[N]> ls ~/.tmux_resurrect/snapshot | awk -F: '/^'test':/ {print $2}' | cut -d\. -f1
0-name
0
0
0
┌─[mzych@marcs-air] - [~/dotfiles] - [Sun Feb 02, 02:04:03]
└─[N]> ls ~/.tmux_resurrect/snapshot | awk -F: '/^'test':/ {print $2}' | cut -d\. -f1 | sort -nu
0-name
┌─[mzych@marcs-air] - [~/dotfiles] - [Sun Feb 02, 02:04:15]
└─[I]> ls ~/.tmux_resurrect/snapshot | awk -F: '/^'test':/ {print $2}' | sed 's/^\([0-9]*\).*/\1/' | sort -nu
0
```
